### PR TITLE
Fix CSP to permit external scripts and OpenAI connections

### DIFF
--- a/client.js
+++ b/client.js
@@ -93,7 +93,12 @@ async function startVoice() {
   const ws = new WebSocket(baseUrl, [
     'realtime',
     'openai-insecure-api-key.' + EPHEMERAL_KEY,
+    // WebSocket subprotocol tokens must be valid HTTP tokens, so
+    // base64url-encode the SDP to avoid `+`, `/`, or `=` characters.
     'openai-sdp.' + btoa(pc.localDescription.sdp)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
   ]);
 
   ws.onmessage = async (event) => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "xr-codelabs",
   "version": "1.0.0",
   "scripts": {
-    "test": "node your-test-runner.js"
+    "test": "node tests/your-test-runner.js"
   }
 }

--- a/tests/your-test-runner.js
+++ b/tests/your-test-runner.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const testsDir = path.join(__dirname, 'tests');
-const testFiles = fs.readdirSync(testsDir).filter(file => file.endsWith('.js'));
+const testsDir = __dirname;
+const testFiles = fs.readdirSync(testsDir)
+  .filter(file => file.endsWith('.js') && file !== 'your-test-runner.js');
 
 let passed = 0;
 

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-eval';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' https://aframe.io; connect-src 'self' https://api.openai.com wss://api.openai.com;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- expand Content-Security-Policy to allow A-Frame CDN script and OpenAI API/WebSocket connections
- fix npm test script and runner to use proper directory
- encode SDP offer with base64url so WebSocket subprotocol complies with RFC token rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20f73b02483319a0cdc0ecb6a2566